### PR TITLE
Music Volume Not Updating Fixed

### DIFF
--- a/Assets/Scenes/MenuMain.unity
+++ b/Assets/Scenes/MenuMain.unity
@@ -12643,7 +12643,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1848865615}
   - component: {fileID: 1848865614}
-  - component: {fileID: 1848865616}
   m_Layer: 0
   m_Name: AudioManager
   m_TagString: AudioManager
@@ -12664,6 +12663,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   references: {fileID: 11400000, guid: c415cd379eedbdb4d8299b6e81efdd9c, type: 2}
+  musicSources: []
 --- !u!4 &1848865615
 Transform:
   m_ObjectHideFlags: 0
@@ -12679,18 +12679,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1848865616
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1848865613}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b8d0d5892c4c1b4f850c24193f2a3a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1868682039
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Starter Scene 1.unity
+++ b/Assets/Scenes/Starter Scene 1.unity
@@ -2568,7 +2568,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1008052322}
   - component: {fileID: 1008052323}
-  - component: {fileID: 1008052324}
   m_Layer: 0
   m_Name: AudioManager
   m_TagString: AudioManager
@@ -2604,18 +2603,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   references: {fileID: 11400000, guid: c415cd379eedbdb4d8299b6e81efdd9c, type: 2}
---- !u!114 &1008052324
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1008052321}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b8d0d5892c4c1b4f850c24193f2a3a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  musicSources: []
 --- !u!1 &1068584564
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Starter Scene 2.unity
+++ b/Assets/Scenes/Starter Scene 2.unity
@@ -2568,7 +2568,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1008052322}
   - component: {fileID: 1008052323}
-  - component: {fileID: 1008052324}
   m_Layer: 0
   m_Name: AudioManager
   m_TagString: AudioManager
@@ -2604,18 +2603,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   references: {fileID: 11400000, guid: c415cd379eedbdb4d8299b6e81efdd9c, type: 2}
---- !u!114 &1008052324
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1008052321}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b8d0d5892c4c1b4f850c24193f2a3a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  musicSources: []
 --- !u!1 &1068584564
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Starter Scene 3.unity
+++ b/Assets/Scenes/Starter Scene 3.unity
@@ -2568,7 +2568,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1008052322}
   - component: {fileID: 1008052323}
-  - component: {fileID: 1008052324}
   m_Layer: 0
   m_Name: AudioManager
   m_TagString: AudioManager
@@ -2604,18 +2603,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   references: {fileID: 11400000, guid: c415cd379eedbdb4d8299b6e81efdd9c, type: 2}
---- !u!114 &1008052324
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1008052321}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b8d0d5892c4c1b4f850c24193f2a3a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  musicSources: []
 --- !u!1 &1068584564
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Starter Scene 4.unity
+++ b/Assets/Scenes/Starter Scene 4.unity
@@ -2568,7 +2568,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1008052322}
   - component: {fileID: 1008052323}
-  - component: {fileID: 1008052324}
   m_Layer: 0
   m_Name: AudioManager
   m_TagString: AudioManager
@@ -2604,18 +2603,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   references: {fileID: 11400000, guid: c415cd379eedbdb4d8299b6e81efdd9c, type: 2}
---- !u!114 &1008052324
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1008052321}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b8d0d5892c4c1b4f850c24193f2a3a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  musicSources: []
 --- !u!1 &1068584564
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Starter Scene 6.unity
+++ b/Assets/Scenes/Starter Scene 6.unity
@@ -2568,7 +2568,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1008052322}
   - component: {fileID: 1008052323}
-  - component: {fileID: 1008052324}
   m_Layer: 0
   m_Name: AudioManager
   m_TagString: AudioManager
@@ -2604,18 +2603,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   references: {fileID: 11400000, guid: c415cd379eedbdb4d8299b6e81efdd9c, type: 2}
---- !u!114 &1008052324
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1008052321}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b8d0d5892c4c1b4f850c24193f2a3a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  musicSources: []
 --- !u!1 &1068584564
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Starter Scene 7.unity
+++ b/Assets/Scenes/Starter Scene 7.unity
@@ -2568,7 +2568,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1008052322}
   - component: {fileID: 1008052323}
-  - component: {fileID: 1008052324}
   m_Layer: 0
   m_Name: AudioManager
   m_TagString: AudioManager
@@ -2604,18 +2603,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   references: {fileID: 11400000, guid: c415cd379eedbdb4d8299b6e81efdd9c, type: 2}
---- !u!114 &1008052324
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1008052321}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b8d0d5892c4c1b4f850c24193f2a3a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  musicSources: []
 --- !u!1 &1068584564
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Starter Scene 8.unity
+++ b/Assets/Scenes/Starter Scene 8.unity
@@ -2568,7 +2568,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1008052322}
   - component: {fileID: 1008052323}
-  - component: {fileID: 1008052324}
   m_Layer: 0
   m_Name: AudioManager
   m_TagString: AudioManager
@@ -2604,18 +2603,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   references: {fileID: 11400000, guid: c415cd379eedbdb4d8299b6e81efdd9c, type: 2}
---- !u!114 &1008052324
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1008052321}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b8d0d5892c4c1b4f850c24193f2a3a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  musicSources: []
 --- !u!1 &1068584564
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Starter Scene 9.unity
+++ b/Assets/Scenes/Starter Scene 9.unity
@@ -2568,7 +2568,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1008052322}
   - component: {fileID: 1008052323}
-  - component: {fileID: 1008052324}
   m_Layer: 0
   m_Name: AudioManager
   m_TagString: AudioManager
@@ -2604,18 +2603,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   references: {fileID: 11400000, guid: c415cd379eedbdb4d8299b6e81efdd9c, type: 2}
---- !u!114 &1008052324
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1008052321}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b8d0d5892c4c1b4f850c24193f2a3a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  musicSources: []
 --- !u!1 &1068584564
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Starter Scene.unity
+++ b/Assets/Scenes/Starter Scene.unity
@@ -2568,7 +2568,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1008052322}
   - component: {fileID: 1008052323}
-  - component: {fileID: 1008052324}
   m_Layer: 0
   m_Name: AudioManager
   m_TagString: AudioManager
@@ -2604,18 +2603,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   references: {fileID: 11400000, guid: c415cd379eedbdb4d8299b6e81efdd9c, type: 2}
---- !u!114 &1008052324
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1008052321}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b8d0d5892c4c1b4f850c24193f2a3a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  musicSources: []
 --- !u!1 &1068584564
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -7,7 +7,7 @@ public class AudioManager : MonoBehaviour
 {
     public AudioReferences references;
     public static Sound[] soundRecords;
-    public static List<AudioSource> musicSources = new List<AudioSource>();
+    public List<AudioSource> musicSources = new List<AudioSource>();
 
     void Awake()
     {

--- a/Assets/Scripts/OptionsHandler.cs
+++ b/Assets/Scripts/OptionsHandler.cs
@@ -30,8 +30,8 @@ public class OptionsHandler : MonoBehaviour
     {
         // Set options to last set value
         OptionsData values = SaveSystem.LoadOptionsData();
-        masterSlider.value = values.masterVolume;
-        effectsSlider.value = values.effectsVolume;
-        musicSlider.value = values.musicVolume;
+        masterSlider.value = values?.masterVolume ?? 0.6f;
+        effectsSlider.value = values?.effectsVolume ?? 0.6f;
+        musicSlider.value = values?.musicVolume ?? 0.6f;
     }
 }

--- a/Assets/Scripts/OptionsHandler.cs
+++ b/Assets/Scripts/OptionsHandler.cs
@@ -18,8 +18,9 @@ public class OptionsHandler : MonoBehaviour
         // If musicSlider changed update all music AudioSource volumes
         if (slider == musicSlider)
         {
-            for (int i = 0; i < AudioManager.musicSources.Count; i++)
-                AudioManager.musicSources[i].volume = slider.value;
+            AudioManager audioManager = GameObject.FindGameObjectWithTag("AudioManager").GetComponent<AudioManager>();
+            for (int i = 0; i < audioManager.musicSources.Count; i++)
+                audioManager.musicSources[i].volume = slider.value;
         }
 
         SaveSystem.SaveOptionsData(this);


### PR DESCRIPTION
I did this by making each `musicSources` component of a `AudioManager` script not `static`. So that each time a new scene was loaded the new audio source could always be updated using (sadly) `GameObject.FindGameObjectWithTag("AudioManager").GetComponent<AudioManager>();` (Line 21 0f OptionsHandler.cs). An added bonus of this however is that AudioManagers have lost the need for `DontDestroyOnLoad()`.