### PR TITLE
Fixed Level Buttons Only Being Clickable In Certain Places.

### DIFF
--- a/Assets/Prefabs/FadeTransition.prefab
+++ b/Assets/Prefabs/FadeTransition.prefab
@@ -307,7 +307,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:


### PR DESCRIPTION
This was done by making the level title text not a raycast target.